### PR TITLE
Close remaining Dependabot alerts (fast-uri, brace-expansion)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   svgo: ^2.8.3
   qs: ^6.15.2
   uuid: ^11.1.1
+  brace-expansion@1: ^1.1.18
+  brace-expansion@2: ^2.1.4
+  brace-expansion@5: ^5.0.9
 
 importers:
 
@@ -2449,14 +2452,14 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.17:
-    resolution: {integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.3:
-    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3063,8 +3066,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -9097,14 +9100,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9311,16 +9314,16 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.17:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10100,7 +10103,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -11239,19 +11242,19 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.17
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,9 @@ allowBuilds:
 # build tooling. Drop an entry once the parent ships a range that allows the fix.
 overrides:
   # ajv@8 pins fast-uri 3.1.2 - GHSA host confusion via backslash authority
-  # delimiter and failed IDN canonicalization
-  fast-uri: ^3.1.4
+  # delimiter and failed IDN canonicalization; 3.1.5 closes the follow-up
+  # CVE-2026-18446 (`\\`, `/\`, `\/` authority introducers)
+  fast-uri: ^3.1.5
   # postcss-svgo@5 pins svgo 2.8.2 - removeScripts plugin leaves some
   # executable scripts intact
   svgo: ^2.8.3
@@ -21,11 +22,11 @@ overrides:
   # fix for the v3/v5/v6 buf bounds check - all three use only the v1/v4 named
   # exports, which uuid 11 still provides
   uuid: ^11.1.1
-
-# NOT overridden: brace-expansion. GHSA-mh99-v99m-4gvg is scoped `<=5.0.7`,
-# which by semver comparison also covers the 1.x and 2.x lines minimatch 3/5
-# depend on, and no fix was backported to those. Forcing 5.x breaks them:
-# brace-expansion 5 exports { expand } while minimatch 3 calls the module
-# itself as a function, so any glob containing `{}` throws
-# "expand is not a function". GitHub auto-dismissed this alert for the same
-# reason. Revisit if minimatch ships a release depending on brace-expansion 5.
+  # brace-expansion DoS via unbounded intermediate arrays. Pinned per major
+  # line, not to 5.x: brace-expansion 5 exports { expand } while minimatch 3
+  # calls the module itself as a function, so a blanket `^5` override makes any
+  # glob containing `{}` throw "expand is not a function". Upstream backported
+  # the fix to every line, so each stays on its own API.
+  brace-expansion@1: ^1.1.18
+  brace-expansion@2: ^2.1.4
+  brace-expansion@5: ^5.0.9


### PR DESCRIPTION
Closes the last two open Dependabot alerts. Both are dev/build-scope transitive deps; nothing changes in the shipped bundle.

**`fast-uri` `^3.1.4` → `^3.1.5`** — [CVE-2026-18446](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), alert #341. Follow-up to the host-confusion issue the existing pin already covered: `\\`, `/\`, and `\/` are treated as authority introducers by Node's WHATWG `URL` but fold into the path under `fast-uri`. Exploiting it requires using `fast-uri` for host policy and then handing the same URL to `fetch()` — that pattern isn't in this repo. `fast-uri` is reached only via `ajv`'s JSON-Schema `$ref` resolution, under `@rushstack/node-core-library` (Heft) and webpack's `schema-utils`.

**`brace-expansion` pinned per major line** — `@1: ^1.1.18`, `@2: ^2.1.4`, `@5: ^5.0.9`. The workspace note said this was unfixable because a blanket `^5` override breaks minimatch 3 (`brace-expansion` 5 exports `{ expand }`, minimatch 3 calls the module itself, so any glob with `{}` throws `expand is not a function`). That reasoning still holds for a blanket override, but is now moot: upstream backported the DoS fix to all three lines, so each parent keeps its own API.

## Verification

- `pnpm audit` → `{info: 0, low: 0, moderate: 0, high: 0, critical: 0}` (was 3 high)
- `pnpm run build` → produces `user-profile-service.sppkg`
- `pnpm exec eslint src --ext .ts,.tsx` → exit 0 (exercises the minimatch glob paths that a bad `brace-expansion` override would break)

🤖 Generated with [Claude Code](https://claude.com/claude-code)